### PR TITLE
Fix navbar agent links

### DIFF
--- a/Server/client-config.sh
+++ b/Server/client-config.sh
@@ -131,6 +131,7 @@ if [[ ${IN_DOCKER} ]]; then
 	/usr/bin/killall sshd
 
 	# lets make an installer pkg!
+	find /var/www/html/ -type d -regextype posix-extended -regex '.*/[^/]{32}$' -prune -exec rm -rf {} \;
 	/usr/local/bin/build_pkg.sh
 	/usr/local/bin/build_admin_pkg.sh
 fi

--- a/docker/build_admin_pkg.sh
+++ b/docker/build_admin_pkg.sh
@@ -66,9 +66,18 @@ echo "osx package has been built: ${PKG_LOCATION}"
 RANDOM_DIR=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1`
 mkdir /var/www/html/"${RANDOM_DIR}"
 ln -s "${PKG_LOCATION}" /var/www/html/"${RANDOM_DIR}"/
-cat <<EOF >> /var/www/html/hooks/agent-links.php
-<ul class="nav navbar-nav">
-  <a href="${RANDOM_DIR}/${APPNAME}-${BLUESKY_VERSION}.pkg" class="btn btn-default navbar-btn visible-sm visible-md visible-lg"><i class="glyphicon glyphicon-download-alt"></i> Download BlueSky Admin Tools</a>
-  <a href="${RANDOM_DIR}/${APPNAME}-${BLUESKY_VERSION}.pkg" class="visible-xs btn btn-default navbar-btn btn-lg"><i class="glyphicon glyphicon-download-alt"></i> Download BlueSky Admin Tools</a>
+if grep -q '<ul class="nav navbar-nav" id="admin_agent">' /var/www/html/hooks/agent-links.php; then
+    # Agent link exists, replace it
+    sed -i "/<ul class=\"nav navbar-nav\" id=\"admin_agent\">/,/<\/ul>/c\\
+<ul class=\"nav navbar-nav\" id=\"admin_agent\">\\
+  <a href=\"${RANDOM_DIR}/${APPNAME}-${BLUESKY_VERSION}.pkg\" class=\"btn btn-default navbar-btn visible-sm visible-md visible-lg\"><i class=\"glyphicon glyphicon-download-alt\"></i>Download BlueSky Admin Tools</a>\\
+  <a href=\"${RANDOM_DIR}/${APPNAME}-${BLUESKY_VERSION}.pkg\" class=\"visible-xs btn btn-default navbar-btn btn-lg\"><i class=\"glyphicon glyphicon-download-alt\"></i>Download BlueSky Admin Tools</a>\\
+</ul>" /var/www/html/hooks/agent-links.php
+else
+    cat <<EOF >> /var/www/html/hooks/agent-links.php
+<ul class="nav navbar-nav" id="admin_agent">
+  <a href="${RANDOM_DIR}/${APPNAME}-${BLUESKY_VERSION}.pkg" class="btn btn-default navbar-btn visible-sm visible-md visible-lg"><i class="glyphicon glyphicon-download-alt"></i>Download BlueSky Admin Tools</a>
+  <a href="${RANDOM_DIR}/${APPNAME}-${BLUESKY_VERSION}.pkg" class="visible-xs btn btn-default navbar-btn btn-lg"><i class="glyphicon glyphicon-download-alt"></i>Download BlueSky Admin Tools</a>
 </ul>
 EOF
+fi

--- a/docker/build_pkg.sh
+++ b/docker/build_pkg.sh
@@ -78,9 +78,18 @@ echo "osx package has been built: ${PKG_LOCATION}"
 RANDOM_DIR=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1`
 mkdir /var/www/html/"${RANDOM_DIR}"
 ln -s "${PKG_LOCATION}" /var/www/html/"${RANDOM_DIR}"/
-cat <<EOF >> /var/www/html/hooks/agent-links.php
-<ul class="nav navbar-nav">
-  <a href="${RANDOM_DIR}/${APPNAME}-${BLUESKY_VERSION}.pkg" class="btn btn-default navbar-btn visible-sm visible-md visible-lg"><i class="glyphicon glyphicon-download-alt"></i> Download BlueSky Agent</a>
-  <a href="${RANDOM_DIR}/${APPNAME}-${BLUESKY_VERSION}.pkg" class="visible-xs btn btn-default navbar-btn btn-lg"><i class="glyphicon glyphicon-download-alt"></i> Download BlueSky Agent</a>
+if grep -q '<ul class="nav navbar-nav" id="agent">' /var/www/html/hooks/agent-links.php; then
+    # Agent link exists, replace it
+    sed -i "/<ul class=\"nav navbar-nav\" id=\"agent\">/,/<\/ul>/c\\
+<ul class=\"nav navbar-nav\" id=\"admin_agent\">\\
+  <a href=\"${RANDOM_DIR}/${APPNAME}-${BLUESKY_VERSION}.pkg\" class=\"btn btn-default navbar-btn visible-sm visible-md visible-lg\"><i class=\"glyphicon glyphicon-download-alt\"></i>Download BlueSky Agent</a>\\
+  <a href=\"${RANDOM_DIR}/${APPNAME}-${BLUESKY_VERSION}.pkg\" class=\"visible-xs btn btn-default navbar-btn btn-lg\"><i class=\"glyphicon glyphicon-download-alt\"></i>Download BlueSky Agent</a>\\
+</ul>" /var/www/html/hooks/agent-links.php
+else
+    cat <<EOF >> /var/www/html/hooks/agent-links.php
+<ul class="nav navbar-nav" id="agent">
+  <a href="${RANDOM_DIR}/${APPNAME}-${BLUESKY_VERSION}.pkg" class="btn btn-default navbar-btn visible-sm visible-md visible-lg"><i class="glyphicon glyphicon-download-alt"></i>Download BlueSky Agent</a>
+  <a href="${RANDOM_DIR}/${APPNAME}-${BLUESKY_VERSION}.pkg" class="visible-xs btn btn-default navbar-btn btn-lg"><i class="glyphicon glyphicon-download-alt"></i>Download BlueSky Agent</a>
 </ul>
 EOF
+fi


### PR DESCRIPTION
fixes issues with the agent links in the web site header. rebooting the docker container was creating duplicates.

also clears previous agent builds between docker reboots.