### PR TITLE
Fix security vulnerabilities identified by Stefan Oberle

### DIFF
--- a/Client/.ssh/wrapper.sh
+++ b/Client/.ssh/wrapper.sh
@@ -14,22 +14,13 @@ if [ "${SSH_ORIGINAL_COMMAND:=UNSET}" == "UNSET" ]; then
 	exit 127
 fi
 
-command="$SSH_ORIGINAL_COMMAND"; export command
-testCmd[1]="/usr/bin/defaults read /var/bluesky/settings serial"
-testCmd[2]="/usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist"
+command="$SSH_ORIGINAL_COMMAND"
 
-for thisCmd in "${testCmd[@]}"; do
-  if [ "$command" == "$thisCmd" ]; then
-    matchCmd="true"
-    break
-  else
-    matchCmd="false"
-  fi
-done
-
-if [ "$matchCmd" == "true" ]; then
-  eval $command
+if [ "$command" == "/usr/bin/defaults read /var/bluesky/settings serial" ]; then
+  /usr/bin/defaults read /var/bluesky/settings serial
+elif [ "$command" == "/usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist" ]; then
+  /usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist
 else
-	echo "invalid command"
-	exit 127
+  echo "invalid command"
+  exit 127
 fi

--- a/Client/.ssh/wrapper.sh
+++ b/Client/.ssh/wrapper.sh
@@ -9,16 +9,16 @@
 # See https://github.com/BlueSkyTools/BlueSkyConnect
 # Licensed under the Apache License, Version 2.0
 
-if [ "${SSH_ORIGINAL_COMMAND:=UNSET}" == "UNSET" ]; then
+if [[ "${SSH_ORIGINAL_COMMAND:=UNSET}" = "UNSET" ]]; then
 	echo "shell access is not permitted for BlueSky"
 	exit 127
 fi
 
 command="$SSH_ORIGINAL_COMMAND"
 
-if [ "$command" == "/usr/bin/defaults read /var/bluesky/settings serial" ]; then
+if [[ "$command" = "/usr/bin/defaults read /var/bluesky/settings serial" ]]; then
   /usr/bin/defaults read /var/bluesky/settings serial
-elif [ "$command" == "/usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist" ]; then
+elif [[ "$command" = "/usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist" ]]; then
   /usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist
 else
   echo "invalid command"

--- a/Server/collector.php
+++ b/Server/collector.php
@@ -35,7 +35,10 @@ if (isset($_POST['serialNum'], $_POST['actionStep']) ) {
         }
 
         // Pass it on
-        $procResult = `/usr/local/bin/BlueSkyConnect/Server/processor.sh "$serialNum" "$actionStep" "$hostName"`;
+        $serialNum = escapeshellarg($serialNum);
+        $actionStep = escapeshellarg($actionStep);
+        $hostName = escapeshellarg($hostName);
+        $procResult = `/usr/local/bin/BlueSkyConnect/Server/processor.sh $serialNum $actionStep $hostName`;
         echo "$procResult";
 
     } else {
@@ -45,8 +48,8 @@ if (isset($_POST['serialNum'], $_POST['actionStep']) ) {
 } else {
 
   if (isset($_POST['newpub']) ) {
-    $pubKey = ($_POST['newpub']);
-    $keyResult = `/usr/local/bin/BlueSkyConnect/Server/keymaster.sh "$pubKey"`;
+    $pubKey = escapeshellarg($_POST['newpub']);
+    $keyResult = `/usr/local/bin/BlueSkyConnect/Server/keymaster.sh $pubKey`;
     echo "$keyResult";
   } else {
     //debugReport=`curl $curlProxy -1 -s -S -m 600 --cacert "$ourHome/cacert.pem" -X POST --data-urlencode "serialNum=$serialNum" --data-urlencode "activity@/tmp/.bluAct" --data-urlencode "main@/tmp/.bluMain" --data-urlencode "helper@/tmp/.bluHelp" --data-urlencode "auto@/tmp/.bluAuto" --data-urlencode "auto1@/tmp/.bluAuto1" --data-urlencode "launchctl@/tmp/.bluLaunchd" --data-urlencode "settings@$ourHome/settings.plist" https://"$serverAddress"/cgi-bin/collector.php`

--- a/Server/html/u_mark_removal.php
+++ b/Server/html/u_mark_removal.php
@@ -28,7 +28,7 @@
 <div class="row">
 <div class="col-md-8 col-lg-10" id="computers_dv_form">
 			<fieldset class="form-horizontal">
-			<input name="selected_ids" type="hidden" value="<?php echo $_REQUEST["selected_ids"];?>">
+			<input name="selected_ids" type="hidden" value="<?php echo htmlspecialchars($_REQUEST["selected_ids"], ENT_QUOTES, 'UTF-8');?>">
 				
 				<div class="form-group">
 					<div class="col-lg-offset-3 col-lg-9">

--- a/Server/html/u_save_removal.php
+++ b/Server/html/u_save_removal.php
@@ -6,12 +6,15 @@
 	
 	$selected_ids=$_REQUEST['selected_ids'];
 	$each_id = explode(",", $selected_ids);
-	
-	$selfdestruct=$_REQUEST['selfdestruct'];
-	
+
+	$selfdestruct = (intval($_REQUEST['selfdestruct']) === 1) ? 1 : 0;
+
 foreach ($each_id as $id) {
-	$query="UPDATE BlueSky.computers SET selfdestruct = '$selfdestruct' WHERE computers.id =$id;";
-    sql($query,$eo);
+	$id = intval($id);
+	if ($id > 0) {
+		$query="UPDATE BlueSky.computers SET selfdestruct = $selfdestruct WHERE computers.id = $id;";
+		sql($query,$eo);
+	}
 
 }
 	

--- a/Server/processor.sh
+++ b/Server/processor.sh
@@ -9,14 +9,14 @@
 # Licensed under the Apache License, Version 2.0
 
 # Escape single quotes for safe MySQL interpolation
-sanitize_sql() {
+sanitizeSql() {
 	echo "${1//\'/\'\'}"
 }
 
 # grab the inputs and sanitize for SQL
-serialNum=$(sanitize_sql "$1")
+serialNum=$(sanitizeSql "$1")
 actionStep="$2"
-hostName=$(sanitize_sql "$3")
+hostName=$(sanitizeSql "$3")
 
 # did we get everything?
 if [ "$serialNum" == "" ] || [ "$actionStep" == "" ]; then
@@ -35,7 +35,7 @@ function allGood {
 
 function snMismatch {
 	echo "Serial mismatch. Returned: $testConn"
-	safeTestConn=$(sanitize_sql "$testConn")
+	safeTestConn=$(sanitizeSql "$testConn")
 	myQry="update computers set status='ERROR: serial mismatch returned $safeTestConn',datetime='$timeStamp' where serialnum='$serialNum'"
 	$myCmd "$myQry"
 }

--- a/Server/processor.sh
+++ b/Server/processor.sh
@@ -8,10 +8,15 @@
 # See https://github.com/BlueSkyTools/BlueSkyConnect
 # Licensed under the Apache License, Version 2.0
 
-# grab the inputs
-serialNum="$1"
+# Escape single quotes for safe MySQL interpolation
+sanitize_sql() {
+	echo "${1//\'/\'\'}"
+}
+
+# grab the inputs and sanitize for SQL
+serialNum=$(sanitize_sql "$1")
 actionStep="$2"
-hostName="$3"
+hostName=$(sanitize_sql "$3")
 
 # did we get everything?
 if [ "$serialNum" == "" ] || [ "$actionStep" == "" ]; then
@@ -30,7 +35,8 @@ function allGood {
 
 function snMismatch {
 	echo "Serial mismatch. Returned: $testConn"
-	myQry="update computers set status='ERROR: serial mismatch returned $testConn',datetime='$timeStamp' where serialnum='$serialNum'"
+	safeTestConn=$(sanitize_sql "$testConn")
+	myQry="update computers set status='ERROR: serial mismatch returned $safeTestConn',datetime='$timeStamp' where serialnum='$serialNum'"
 	$myCmd "$myQry"
 }
 

--- a/Server/update-from-git.sh
+++ b/Server/update-from-git.sh
@@ -34,7 +34,8 @@ if [ -d /usr/local/bin/BlueSky ] && [ ! -d /usr/local/bin/BlueSkyConnect ]; then
   # root crontab entries (@reboot startGozer, purgeTemp, serverup)
   crontab -l 2> /dev/null | sed 's|/usr/local/bin/BlueSky/|/usr/local/bin/BlueSkyConnect/|g' | crontab -
 
-  # forced-command prefix in authorized_keys for both roles
+  # forced-command prefix in authorized_keys for both roles.
+  # Note: one-shot. Future wrapper.sh path/contract changes need a new migration block.
   for keyFile in /home/admin/.ssh/authorized_keys /home/bluesky/.ssh/authorized_keys; do
     if [ -f "$keyFile" ]; then
       sed -i 's|/usr/local/bin/BlueSky/Server|/usr/local/bin/BlueSkyConnect/Server|g' "$keyFile"
@@ -101,6 +102,14 @@ if [ "$mysqlCollectorPass" == "" ]; then
   myQry="grant select on BlueSky.computers to 'collector'@'localhost';"
   $myCmd "$myQry"
 fi
+## Refresh /usr/lib/cgi-bin/collector.php from canonical source on every run.
+## The install-time ln -fs was broken by sed -i CHANGETHIS, leaving a regular
+## file frozen at install content; canonical-file changes (security fixes,
+## new shell-outs) otherwise never reach what Apache actually serves.
+cp /usr/local/bin/BlueSkyConnect/Server/collector.php /usr/lib/cgi-bin/collector.php
+chown www-data /usr/lib/cgi-bin/collector.php
+chmod 700 /usr/lib/cgi-bin/collector.php
+
 sed -i "s/CHANGETHIS/$(printf '%s\n' "$mysqlCollectorPass" | sed 's/[\/&]/\\&/g')/g" /usr/lib/cgi-bin/collector.php
 
 ## double-check permissions on uploaded BlueSky files


### PR DESCRIPTION
## Summary

Addresses security vulnerabilities identified by Stefan Oberle across the collector, processor, removal endpoints, and SSH wrapper. Also fixes a deployment bug in `update-from-git.sh` discovered during verification: `/usr/lib/cgi-bin/collector.php` (the file Apache actually serves) was frozen at install-time content and never refreshed on subsequent runs, so security fixes silently failed to deploy on non-Docker hosts.

- **`Server/collector.php`** — shell injection: `$serialNum`, `$actionStep`, `$hostName`, and `$pubKey` are now passed through `escapeshellarg()` before being interpolated into the shell-outs to `processor.sh` and `keymaster.sh`.
- **`Server/processor.sh`** — SQL injection: incoming `$serialNum`, `$hostName`, and the `$testConn` value used in the serial-mismatch error path are escaped for single-quote interpolation before being embedded in MySQL `UPDATE` / `INSERT` statements via a new `sanitizeSql` helper.
- **`Server/html/u_save_removal.php`** — SQL injection: `selected_ids` parts and `selfdestruct` are now `intval()`-cast before being embedded in the UPDATE statement.
- **`Server/html/u_mark_removal.php`** — XSS: `selected_ids` is reflected through `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` before being rendered into the hidden form field.
- **`Client/.ssh/wrapper.sh`** — replaces the array-iterated `eval $command` allow-list with explicit per-command branches, eliminating the eval and the indirection through `$matchCmd`. Same two allowed commands as before; anything else exits 127.
- **`Server/update-from-git.sh`** — re-syncs `/usr/lib/cgi-bin/collector.php` from the canonical source on every run. The install-time `ln -fs` was broken by `sed -i CHANGETHIS`, leaving a frozen regular file; without this `cp`, the `collector.php` fix above doesn't reach non-Docker hosts.

## Verification

Tested end-to-end against the bare-metal test server (10.1.50.135) and Docker production (bluesky.thirdvantage.com):

- [x] **Docker image builds and runs cleanly** (operator-reported, pushed as `security-fix` tag).
- [x] **Register a fresh client** — collector → processor → MySQL insert succeeded with `escapeshellarg` + `sanitizeSql` on the happy path. Verified on both test server (post-update) and production.
- [x] **POST `serialNum` containing a single quote** — `serialNum=PROBE-SQL-...'OR'1'='1` → row inserted cleanly, no SQL error.
- [x] **POST shell-injection payloads to `collector.php`** — backticks, `$()`, and timing-based `$(/bin/sleep 8)` in `serialNum`, `hostName`, and `actionStep`. All neutralized on production (~36–140ms responses). On the test server, the sleep payload dropped from **8.12s (vulnerable)** to **36ms (neutralized)** after the `update-from-git.sh` `cp` fix landed.
- [x] **`u_mark_removal.php` XSS** — `selected_ids=<script>alert(1)</script>` reflected as `&lt;script&gt;alert(1)&lt;/script&gt;`.
- [x] **`u_save_removal.php` SQL injection** — five payloads (quote+OR, stacked `SELECT SLEEP(8)`, UNION extraction, `selfdestruct` param injection, comma-split injection in second ID): all returned <120ms with no errors or data leakage.
- [x] **Non-Docker `update-from-git.sh` deploys the new `collector.php`** — confirmed by running the updated script on the test server and re-probing; `escapeshellarg` calls now present in `/usr/lib/cgi-bin/collector.php`.

### Deferred (not exercised this round)

- **`newpub` key enrollment via `collector.php` + `keymaster.sh`** — the only `keymaster.sh`-relevant change in this branch is the `escapeshellarg` on `$pubKey`. PKCS7 decryption path itself is unchanged.
- **`Client/.ssh/wrapper.sh` allow-list end-to-end** — would require building a fresh client `.pkg` and installing on a test Mac. Diff is functionally identical to the pre-fix code (same two-entry allow-list, `if/elif` instead of `for/eval`); no new behavior to validate, low risk.
- **Anonymous `ssh -p 3122 bluesky@SERVER 'id'` refused** — `bluesky-wrapper.sh` server-side allow-list is unchanged by this branch.

## Notes for reviewers

- Comparison with PR #58: that PR proposes equivalent shell-out hardening on `collector.php` (using `shell_exec(... . escapeshellarg(...))` rather than backticks — functionally identical to this branch's approach) plus a PKCS7 format pre-check on `newpub`. We considered incorporating the PKCS7 check but skipped it: it relies on PEM headers, and DER-encoded SMIME would be rejected. `keymaster.sh` already validates by attempting decryption with the known keys.
- Conventions cleanup commit (`6bc79f2`) renames `sanitize_sql` → `sanitizeSql` per CONTRIBUTING.md camelCase rule and aligns `wrapper.sh` with the `[[ ]]` / `=` / trailing-newline conventions.
- Pre-existing in `Server/processor.sh`: ~20 SC2006 (legacy backticks), plus SC2086/SC2034/SC2181 warnings, and file-wide tab indentation that conflicts with `.editorconfig`. None of these were introduced or touched by this branch; left out of scope to keep the security commits focused.
- `update-from-git.sh` also picks up a one-line heads-up at the `authorized_keys` migration that the path-rewrite is one-shot — future wrapper.sh path/contract changes will need a new migration block.

## Upgrade procedure for non-Docker hosts

Because the `update-from-git.sh` already on a deployed box has no knowledge of the `cp` step, operators must download the new script first (same pattern PR #59 documented for 2.3.2 → 2.5.0):

```bash
sudo curl -fsSL https://raw.githubusercontent.com/BlueSkyTools/BlueSkyConnect/dev-2.x/Server/update-from-git.sh \
  -o /tmp/update-from-git.sh
sudo bash /tmp/update-from-git.sh
```

Docker hosts are unaffected — `server-config.sh` re-runs on container start and `ln -fs` makes a fresh symlink from the just-built image.
