### PR TITLE
Release 2.5.1: merge dev-2.x into master

### DIFF
--- a/Client/.ssh/wrapper.sh
+++ b/Client/.ssh/wrapper.sh
@@ -14,22 +14,13 @@ if [ "${SSH_ORIGINAL_COMMAND:=UNSET}" == "UNSET" ]; then
 	exit 127
 fi
 
-command="$SSH_ORIGINAL_COMMAND"; export command
-testCmd[1]="/usr/bin/defaults read /var/bluesky/settings serial"
-testCmd[2]="/usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist"
+command="$SSH_ORIGINAL_COMMAND"
 
-for thisCmd in "${testCmd[@]}"; do
-  if [ "$command" == "$thisCmd" ]; then
-    matchCmd="true"
-    break
-  else
-    matchCmd="false"
-  fi
-done
-
-if [ "$matchCmd" == "true" ]; then
-  eval $command
+if [ "$command" == "/usr/bin/defaults read /var/bluesky/settings serial" ]; then
+  /usr/bin/defaults read /var/bluesky/settings serial
+elif [ "$command" == "/usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist" ]; then
+  /usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist
 else
-	echo "invalid command"
-	exit 127
+  echo "invalid command"
+  exit 127
 fi

--- a/Client/.ssh/wrapper.sh
+++ b/Client/.ssh/wrapper.sh
@@ -9,16 +9,16 @@
 # See https://github.com/BlueSkyTools/BlueSkyConnect
 # Licensed under the Apache License, Version 2.0
 
-if [ "${SSH_ORIGINAL_COMMAND:=UNSET}" == "UNSET" ]; then
+if [[ "${SSH_ORIGINAL_COMMAND:=UNSET}" = "UNSET" ]]; then
 	echo "shell access is not permitted for BlueSky"
 	exit 127
 fi
 
 command="$SSH_ORIGINAL_COMMAND"
 
-if [ "$command" == "/usr/bin/defaults read /var/bluesky/settings serial" ]; then
+if [[ "$command" = "/usr/bin/defaults read /var/bluesky/settings serial" ]]; then
   /usr/bin/defaults read /var/bluesky/settings serial
-elif [ "$command" == "/usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist" ]; then
+elif [[ "$command" = "/usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist" ]]; then
   /usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist
 else
   echo "invalid command"

--- a/Client/bluesky.sh
+++ b/Client/bluesky.sh
@@ -11,7 +11,7 @@
 # Set this to a different location if you'd prefer it live somewhere else
 ourHome="/var/bluesky"
 
-bVer="2.5.0"
+bVer="2.5.1"
 
 # planting a debug flag runs bash in -x so you get all the output
 if [ -e "$ourHome/.debug" ]; then

--- a/Client/helper.sh
+++ b/Client/helper.sh
@@ -8,7 +8,7 @@
 # Licensed under the Apache License, Version 2.0
 
 ourHome="/var/bluesky"
-bVer="2.5.0"
+bVer="2.5.1"
 
 if [ -e "$ourHome/.debug" ]; then
   set -x

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV IN_DOCKER=1 \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     DEBIAN_FRONTEND=noninteractive \
-    BLUESKY_VERSION=2.5.0
+    BLUESKY_VERSION=2.5.1
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y apache2 \

--- a/Server/collector.php
+++ b/Server/collector.php
@@ -35,7 +35,10 @@ if (isset($_POST['serialNum'], $_POST['actionStep']) ) {
         }
 
         // Pass it on
-        $procResult = `/usr/local/bin/BlueSkyConnect/Server/processor.sh "$serialNum" "$actionStep" "$hostName"`;
+        $serialNum = escapeshellarg($serialNum);
+        $actionStep = escapeshellarg($actionStep);
+        $hostName = escapeshellarg($hostName);
+        $procResult = `/usr/local/bin/BlueSkyConnect/Server/processor.sh $serialNum $actionStep $hostName`;
         echo "$procResult";
 
     } else {
@@ -45,8 +48,8 @@ if (isset($_POST['serialNum'], $_POST['actionStep']) ) {
 } else {
 
   if (isset($_POST['newpub']) ) {
-    $pubKey = ($_POST['newpub']);
-    $keyResult = `/usr/local/bin/BlueSkyConnect/Server/keymaster.sh "$pubKey"`;
+    $pubKey = escapeshellarg($_POST['newpub']);
+    $keyResult = `/usr/local/bin/BlueSkyConnect/Server/keymaster.sh $pubKey`;
     echo "$keyResult";
   } else {
     //debugReport=`curl $curlProxy -1 -s -S -m 600 --cacert "$ourHome/cacert.pem" -X POST --data-urlencode "serialNum=$serialNum" --data-urlencode "activity@/tmp/.bluAct" --data-urlencode "main@/tmp/.bluMain" --data-urlencode "helper@/tmp/.bluHelp" --data-urlencode "auto@/tmp/.bluAuto" --data-urlencode "auto1@/tmp/.bluAuto1" --data-urlencode "launchctl@/tmp/.bluLaunchd" --data-urlencode "settings@$ourHome/settings.plist" https://"$serverAddress"/cgi-bin/collector.php`

--- a/Server/html/u_mark_removal.php
+++ b/Server/html/u_mark_removal.php
@@ -28,7 +28,7 @@
 <div class="row">
 <div class="col-md-8 col-lg-10" id="computers_dv_form">
 			<fieldset class="form-horizontal">
-			<input name="selected_ids" type="hidden" value="<?php echo $_REQUEST["selected_ids"];?>">
+			<input name="selected_ids" type="hidden" value="<?php echo htmlspecialchars($_REQUEST["selected_ids"], ENT_QUOTES, 'UTF-8');?>">
 				
 				<div class="form-group">
 					<div class="col-lg-offset-3 col-lg-9">

--- a/Server/html/u_save_removal.php
+++ b/Server/html/u_save_removal.php
@@ -6,12 +6,15 @@
 	
 	$selected_ids=$_REQUEST['selected_ids'];
 	$each_id = explode(",", $selected_ids);
-	
-	$selfdestruct=$_REQUEST['selfdestruct'];
-	
+
+	$selfdestruct = (intval($_REQUEST['selfdestruct']) === 1) ? 1 : 0;
+
 foreach ($each_id as $id) {
-	$query="UPDATE BlueSky.computers SET selfdestruct = '$selfdestruct' WHERE computers.id =$id;";
-    sql($query,$eo);
+	$id = intval($id);
+	if ($id > 0) {
+		$query="UPDATE BlueSky.computers SET selfdestruct = $selfdestruct WHERE computers.id = $id;";
+		sql($query,$eo);
+	}
 
 }
 	

--- a/Server/processor.sh
+++ b/Server/processor.sh
@@ -9,14 +9,14 @@
 # Licensed under the Apache License, Version 2.0
 
 # Escape single quotes for safe MySQL interpolation
-sanitize_sql() {
+sanitizeSql() {
 	echo "${1//\'/\'\'}"
 }
 
 # grab the inputs and sanitize for SQL
-serialNum=$(sanitize_sql "$1")
+serialNum=$(sanitizeSql "$1")
 actionStep="$2"
-hostName=$(sanitize_sql "$3")
+hostName=$(sanitizeSql "$3")
 
 # did we get everything?
 if [ "$serialNum" == "" ] || [ "$actionStep" == "" ]; then
@@ -35,7 +35,7 @@ function allGood {
 
 function snMismatch {
 	echo "Serial mismatch. Returned: $testConn"
-	safeTestConn=$(sanitize_sql "$testConn")
+	safeTestConn=$(sanitizeSql "$testConn")
 	myQry="update computers set status='ERROR: serial mismatch returned $safeTestConn',datetime='$timeStamp' where serialnum='$serialNum'"
 	$myCmd "$myQry"
 }

--- a/Server/processor.sh
+++ b/Server/processor.sh
@@ -8,10 +8,15 @@
 # See https://github.com/BlueSkyTools/BlueSkyConnect
 # Licensed under the Apache License, Version 2.0
 
-# grab the inputs
-serialNum="$1"
+# Escape single quotes for safe MySQL interpolation
+sanitize_sql() {
+	echo "${1//\'/\'\'}"
+}
+
+# grab the inputs and sanitize for SQL
+serialNum=$(sanitize_sql "$1")
 actionStep="$2"
-hostName="$3"
+hostName=$(sanitize_sql "$3")
 
 # did we get everything?
 if [ "$serialNum" == "" ] || [ "$actionStep" == "" ]; then
@@ -30,7 +35,8 @@ function allGood {
 
 function snMismatch {
 	echo "Serial mismatch. Returned: $testConn"
-	myQry="update computers set status='ERROR: serial mismatch returned $testConn',datetime='$timeStamp' where serialnum='$serialNum'"
+	safeTestConn=$(sanitize_sql "$testConn")
+	myQry="update computers set status='ERROR: serial mismatch returned $safeTestConn',datetime='$timeStamp' where serialnum='$serialNum'"
 	$myCmd "$myQry"
 }
 

--- a/Server/update-from-git.sh
+++ b/Server/update-from-git.sh
@@ -34,7 +34,8 @@ if [ -d /usr/local/bin/BlueSky ] && [ ! -d /usr/local/bin/BlueSkyConnect ]; then
   # root crontab entries (@reboot startGozer, purgeTemp, serverup)
   crontab -l 2> /dev/null | sed 's|/usr/local/bin/BlueSky/|/usr/local/bin/BlueSkyConnect/|g' | crontab -
 
-  # forced-command prefix in authorized_keys for both roles
+  # forced-command prefix in authorized_keys for both roles.
+  # Note: one-shot. Future wrapper.sh path/contract changes need a new migration block.
   for keyFile in /home/admin/.ssh/authorized_keys /home/bluesky/.ssh/authorized_keys; do
     if [ -f "$keyFile" ]; then
       sed -i 's|/usr/local/bin/BlueSky/Server|/usr/local/bin/BlueSkyConnect/Server|g' "$keyFile"
@@ -101,6 +102,14 @@ if [ "$mysqlCollectorPass" == "" ]; then
   myQry="grant select on BlueSky.computers to 'collector'@'localhost';"
   $myCmd "$myQry"
 fi
+## Refresh /usr/lib/cgi-bin/collector.php from canonical source on every run.
+## The install-time ln -fs was broken by sed -i CHANGETHIS, leaving a regular
+## file frozen at install content; canonical-file changes (security fixes,
+## new shell-outs) otherwise never reach what Apache actually serves.
+cp /usr/local/bin/BlueSkyConnect/Server/collector.php /usr/lib/cgi-bin/collector.php
+chown www-data /usr/lib/cgi-bin/collector.php
+chmod 700 /usr/lib/cgi-bin/collector.php
+
 sed -i "s/CHANGETHIS/$(printf '%s\n' "$mysqlCollectorPass" | sed 's/[\/&]/\\&/g')/g" /usr/lib/cgi-bin/collector.php
 
 ## double-check permissions on uploaded BlueSky files


### PR DESCRIPTION
## Summary

Promotes `dev-2.x` to `master` as the **2.5.1 security release**. All changes here have already been merged into `dev-2.x` (most recently via #62) and verified end-to-end against the bare-metal test server and Docker production.

## What's in this release

### Security fixes (responsible disclosure: @dircadmin / Stefan Oberle)

- **Shell injection in `Server/collector.php`** — POST parameters (`serialNum`, `actionStep`, `hostName`, `newpub`) now pass through `escapeshellarg()` before being interpolated into the shell-outs to `processor.sh` and `keymaster.sh`.
- **SQL injection in `Server/processor.sh`** — `serialNum`, `hostName`, and the `testConn` echo-back value are now escaped through a new `sanitizeSql` helper before reaching MySQL string literals.
- **SQL injection in `Server/html/u_save_removal.php`** — `selected_ids` parts and `selfdestruct` flag are `intval()`-cast before reaching the `UPDATE` statement.
- **Reflected XSS in `Server/html/u_mark_removal.php`** — `selected_ids` is run through `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` before being rendered into the hidden form field.
- **SSH wrapper hardening (`Client/.ssh/wrapper.sh`)** — replaces `eval`-against-an-allow-list with explicit per-command branches. Allow-list unchanged.

### Deployment fix

- **`Server/update-from-git.sh` re-syncs `/usr/lib/cgi-bin/collector.php` on every run.** The install-time `ln -fs` was broken by the `sed -i CHANGETHIS` substitution, leaving a frozen regular file that subsequent `git reset --hard` operations never refreshed. Without this `cp`, the `collector.php` fix above does not deploy on non-Docker hosts (verified: shell-injection payload took 8.12s → 36ms before/after the deployment fix on the test server).

### Infrastructure

- Container image moved to **`ghcr.io/blueskytools/blueskyconnect`**. Docker Hub (`sphen/bluesky`) is no longer updated.
- GitHub Actions workflow builds and publishes the image automatically.

## Upgrade path

### Non-Docker hosts

The `update-from-git.sh` already on a 2.5.0 box doesn't know about the new `cp` step. Download the new script first (same pattern PR #59 documented):

```bash
sudo curl -fsSL https://raw.githubusercontent.com/BlueSkyTools/BlueSkyConnect/master/Server/update-from-git.sh \
  -o /tmp/update-from-git.sh
sudo bash /tmp/update-from-git.sh
```

Verify with `grep -c escapeshellarg /usr/lib/cgi-bin/collector.php` (expect `4`).

### Docker hosts

Switch any `docker pull` / `docker-compose.yml` references from `sphen/bluesky` to `ghcr.io/blueskytools/blueskyconnect`. Existing containers keep running but won't receive this update otherwise.

## Test plan

- [x] All security probes verified end-to-end (see #62 for the full test matrix).
- [x] `update-from-git.sh` re-sync verified on the bare-metal test server.
- [x] Docker image rebuilt and verified clean on production (`bluesky.thirdvantage.com`).
- [ ] Tag `v2.5.1` and publish the draft release once this PR merges.
