### PR TITLE
Fix SQL syntax error for hostnames with single quotes

### DIFF
--- a/Server/collector.php
+++ b/Server/collector.php
@@ -26,10 +26,11 @@ if (isset($_POST['serialNum'], $_POST['actionStep']) ) {
     if ($dbc) {
 
         // Sanctify the provided information:
-        $serialNum = mysqli_real_escape_string($dbc, trim($_POST['serialNum']));
-        $actionStep = mysqli_real_escape_string($dbc, trim($_POST['actionStep']));
+        // SQL escaping is handled by processor.sh; here we only need shell escaping.
+        $serialNum = trim($_POST['serialNum']);
+        $actionStep = trim($_POST['actionStep']);
         if (isset($_POST['hostName']) ) {
-        	$hostName = mysqli_real_escape_string($dbc, trim($_POST['hostName']));
+        	$hostName = trim($_POST['hostName']);
         } else {
         	$hostName = "";
         }

--- a/Server/processor.sh
+++ b/Server/processor.sh
@@ -8,9 +8,11 @@
 # See https://github.com/BlueSkyTools/BlueSkyConnect
 # Licensed under the Apache License, Version 2.0
 
-# Escape single quotes for safe MySQL interpolation
+# Escape backslashes and single quotes for safe MySQL interpolation.
+# Backslashes must be escaped first so the quotes we add aren't themselves escaped.
 sanitizeSql() {
-	echo "${1//\'/\'\'}"
+	local s="${1//\\/\\\\}"
+	echo "${s//\'/\'\'}"
 }
 
 # grab the inputs and sanitize for SQL


### PR DESCRIPTION
Fixes #64 — thanks to @grigutis for the clear report and reproduction.

## Background

After #62 was merged into 2.5.1, any client whose hostname contained a straight single quote (e.g. `User's MacBook Air`) failed to register with:

```
ERROR 1064 (42000) at line 1: You have an error in your SQL syntax;
... near 's MacBook Air' where id='29'' at line 1
```

The two security patches independently escape for SQL, but using different conventions, and the result is a malformed `\''` sequence that MySQL can't parse.

### Trace

For input `User's MacBook Air`:

1. `collector.php` calls `mysqli_real_escape_string()` — `'` becomes `\'`
2. `collector.php` then `escapeshellarg()`s and hands to `processor.sh`
3. `processor.sh`'s `sanitizeSql` doubles every `'`, so `\'` becomes `\''`
4. SQL is built: `sharingname='User\''s MacBook Air' where id='29'`
5. MySQL parses `\'` as one literal `'`, then the next `'` ends the string, leaving `s MacBook Air' where id='29'` as garbage — hence the 1064 error.

## Changes

**1. `Server/collector.php` — remove the now-redundant `mysqli_real_escape_string()` calls.**

`processor.sh` owns SQL escaping for these arguments since #62. The PHP layer only needs `escapeshellarg()` for the shell hop.

**2. `Server/processor.sh` — harden `sanitizeSql` against backslash injection.**

While verifying the first fix, I noticed `sanitizeSql` only handled `'` and not `\`. Under MySQL's default backslash-escape mode, an input like `Inject\'; DROP TABLE computers; --` could break out of the string literal and run a second statement (`mysql -e` accepts multi-statement input). This is a latent flaw introduced by #62 — the original pre-#62 code was safe because `mysqli_real_escape_string` was escaping backslashes too. The fix escapes backslashes first, then doubles the quotes.

## Verification

End-to-end PHP→shell→SQL with a range of inputs (legit single quotes, curly quotes, multiple quotes, backslashes, and injection payloads) all produce well-formed SQL where the value lands intact in the database. Curly-quote names (e.g. `User's MacBook Pro`, U+2019) were never affected by the bug since neither escape layer targets them.

## Risk

Low. Removing `mysqli_real_escape_string` from `collector.php` does not reopen anything — its only role was SQL escaping, now handled by `sanitizeSql`. Shell injection is still blocked by `escapeshellarg()`.
