### PR TITLE
Exclude pre-release tags from floating major/minor image tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,8 +45,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-') }}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-') }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push


### PR DESCRIPTION
Pre-release tags (e.g. v2.6.0-rc.1) previously produced the floating
:{major}.{minor} and :{major} image tags alongside :{version}, so users
pulling :2.6 or :2 would silently land on an RC build. Gate those two
patterns on tags without a SemVer pre-release identifier so RC tags
only publish the fully qualified :2.6.0-rc.1 image. The :latest tag is
already restricted to default-branch pushes and is unaffected.