### PR TITLE
Log rotation & stream to docker stdout / Cron fix.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ENV IN_DOCKER=1 \
     MYSQLSERVER=db \
     WEBADMINPASS=admin \
     EMAILALERT=root@localhost \
+    LOG_ROTATE_SIZE=100M \
+    LOG_ROTATE_KEEP=7 \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     DEBIAN_FRONTEND=noninteractive \
@@ -31,6 +33,7 @@ RUN apt-get update && \
     rsyslog \
     fail2ban \
     iptables \
+    logrotate \
     uuid-runtime \
     libnet-ssleay-perl \
     ca-certificates && \

--- a/Server/processor.sh
+++ b/Server/processor.sh
@@ -137,7 +137,7 @@ fi
 myQry="select blueskyid from computers where serialnum='$serialNum'"
 myPort=`$myCmd "$myQry"`
 sshPort=$((22000 + myPort))
-testConn=`ssh -p $sshPort -o StrictHostKeyChecking=no -o ConnectTimeout=10 -l bluesky -o BatchMode=yes -i /usr/local/bin/BlueSkyConnect/Server/blueskyd localhost "/usr/bin/defaults read /var/bluesky/settings serial"`
+testConn=`ssh -p $sshPort -o StrictHostKeyChecking=no -o LogLevel=ERROR -o ConnectTimeout=10 -l bluesky -o BatchMode=yes -i /usr/local/bin/BlueSkyConnect/Server/blueskyd localhost "/usr/bin/defaults read /var/bluesky/settings serial"`
 testExit=$?
 if [ $testExit -eq 0 ]; then
   if [ "$testConn" == "$serialNum" ]; then
@@ -146,7 +146,7 @@ if [ $testExit -eq 0 ]; then
     snMismatch
   fi
 else #either down or defaults is messed up, try using PlistBuddy
-	testConn2=`ssh -p $sshPort -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o BatchMode=yes -l bluesky -i /usr/local/bin/BlueSkyConnect/Server/blueskyd localhost "/usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist" 2>&1`
+	testConn2=`ssh -p $sshPort -o StrictHostKeyChecking=no -o LogLevel=ERROR -o ConnectTimeout=10 -o BatchMode=yes -l bluesky -i /usr/local/bin/BlueSkyConnect/Server/blueskyd localhost "/usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist" 2>&1`
 	testExit2=$?
 	if [ $testExit2 -eq 0 ]; then
 		if [ "$testConn2" == "$serialNum" ]; then

--- a/Server/server-config.sh
+++ b/Server/server-config.sh
@@ -59,6 +59,47 @@ if [[ ${IN_DOCKER} ]]; then
     echo ${TIMEZONE} > /etc/timezone
     dpkg-reconfigure -f noninteractive tzdata
   fi
+
+  ## install consolidated logrotate config for apache/auth/fail2ban
+  : "${LOG_ROTATE_SIZE:=100M}"
+  : "${LOG_ROTATE_KEEP:=7}"
+  # drop distro configs that conflict with our entries
+  rm -f /etc/logrotate.d/apache2 /etc/logrotate.d/fail2ban
+  # rsyslog ships auth.log inside a multi-path block; strip just that path
+  if [[ -f /etc/logrotate.d/rsyslog ]]; then
+    sed -i '\|^/var/log/auth\.log$|d' /etc/logrotate.d/rsyslog
+  fi
+  cat > /etc/logrotate.d/bluesky <<EOF
+/var/log/apache2/*.log {
+  size ${LOG_ROTATE_SIZE}
+  rotate ${LOG_ROTATE_KEEP}
+  missingok
+  notifempty
+  compress
+  delaycompress
+  copytruncate
+}
+
+/var/log/auth.log {
+  size ${LOG_ROTATE_SIZE}
+  rotate ${LOG_ROTATE_KEEP}
+  missingok
+  notifempty
+  compress
+  delaycompress
+  copytruncate
+}
+
+/var/log/fail2ban.log {
+  size ${LOG_ROTATE_SIZE}
+  rotate ${LOG_ROTATE_KEEP}
+  missingok
+  notifempty
+  compress
+  delaycompress
+  copytruncate
+}
+EOF
 fi
 if [ "$USE_HTTP" -eq "1" ]; then
   apacheConf="000-default"

--- a/Server/server-config.sh
+++ b/Server/server-config.sh
@@ -236,6 +236,9 @@ if [ "$USE_HTTP" -ne "1" ]; then
   a2enmod ssl
   a2ensite default-ssl
 fi
+if [ "$USE_HTTP" -eq "1" ]; then
+  a2enmod remoteip
+fi
 a2enmod cgi
 sed -i "s/ServerAdmin webmaster@localhost/ServerAdmin $emailAlertAddress/g" /etc/apache2/sites-enabled/"$apacheConf".conf
 
@@ -249,6 +252,12 @@ else
   # Honor an upstream reverse proxy's X-Forwarded-Proto so AppGini's $_SERVER['HTTPS']
   # check sees 'on' and generates https:// redirects instead of http://.
   echo '    SetEnvIf X-Forwarded-Proto "https" HTTPS=on' >> /tmp/"$apacheConf".conf
+  # Honor X-Forwarded-For so access/error logs and REMOTE_ADDR show real client IPs.
+  echo '    RemoteIPHeader X-Forwarded-For' >> /tmp/"$apacheConf".conf
+  echo '    RemoteIPInternalProxy 127.0.0.1' >> /tmp/"$apacheConf".conf
+  echo '    RemoteIPInternalProxy 10.0.0.0/8' >> /tmp/"$apacheConf".conf
+  echo '    RemoteIPInternalProxy 172.16.0.0/12' >> /tmp/"$apacheConf".conf
+  echo '    RemoteIPInternalProxy 192.168.0.0/16' >> /tmp/"$apacheConf".conf
 fi
 #write the bottom half
 tail -n +6 /etc/apache2/sites-enabled/"$apacheConf".conf  >> /tmp/"$apacheConf".conf

--- a/Server/serverup.sh
+++ b/Server/serverup.sh
@@ -56,7 +56,7 @@ for serialNum in $alertList; do
 		myQry="select blueskyid from computers where serialnum='$serialNum'"
 		myPort=`$myCmd "$myQry"`
 		sshPort=$((22000 + myPort))
-		testSN=`ssh -p $sshPort -o ConnectTimeout=5 -o ConnectionAttempts=5 -o StrictHostKeyChecking=no -l bluesky -i /usr/local/bin/BlueSkyConnect/Server/blueskyd localhost "/usr/bin/defaults read /var/bluesky/settings serial"`
+		testSN=`ssh -p $sshPort -o ConnectTimeout=5 -o ConnectionAttempts=5 -o StrictHostKeyChecking=no -o LogLevel=ERROR -l bluesky -i /usr/local/bin/BlueSkyConnect/Server/blueskyd localhost "/usr/bin/defaults read /var/bluesky/settings serial"`
 		testExit=$?
 		if [ $testExit -ne 0 ]; then
 		  # we did not connect, mark down the counter

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,6 +29,8 @@ SMTP_SERVER | | SMTP Server (Required for email alerts) Port optional
 SMTP_AUTH | | SMTP auth user (Required for email alerts)
 SMTP_PASS | | SMTP auth pass (Required for email alerts)
 TIMEZONE | Etc/UTC | Local Timezone [Reference](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+LOG_ROTATE_SIZE | 100M | Size threshold for log rotation (applies to Apache, auth, and fail2ban logs)
+LOG_ROTATE_KEEP | 7 | Number of rotated copies to retain (older are deleted)
 DEFAULT_USER | | Default username bluesky uses when connecting to a client
 INSECURE_CIPHERS | | Set to any value to allow the use of chacha20-poly1305 ssh cipher (bluesky <= 2.3.2)
 
@@ -147,6 +149,8 @@ You can also shell into the BlueSky container if needed.  For example:
 ```
 docker exec -it bluesky bash
 ```
+
+Apache request and error logs are mirrored to the container's stdout in addition to being written to `/var/log/apache2/` inside the container, so `docker logs bluesky` is useful for live troubleshooting while the on-disk files remain available via `docker exec`.  All three log groups (`/var/log/apache2/*.log`, `/var/log/auth.log`, `/var/log/fail2ban.log`) are rotated by `logrotate` (run via cron); see `LOG_ROTATE_SIZE` and `LOG_ROTATE_KEEP` above to tune.
 
 ### Links
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ Variable | Default Value | Note
 --- | --- | ---
 SERVERFQDN | localhost | BlueSky FQDN
 WEBADMINPASS | admin |
-USE_HTTP | 0 | Set to 1 to serve plain HTTP (recommended when running behind a TLS-terminating reverse proxy such as Caddy/nginx; container honors X-Forwarded-Proto)
+USE_HTTP | 0 | Set to 1 to serve plain HTTP (recommended when running behind a TLS-terminating reverse proxy such as Caddy/nginx; container honors X-Forwarded-Proto and X-Forwarded-For so access/error logs and `REMOTE_ADDR` show the real client IP)
 SSL_CERT | | Filename referring to your ssl cert file in /certs
 SSL_KEY | | Filename referring to your ssl key file in /certs
 FAIL2BAN | 1 | Set to 0 to disable fail2ban
@@ -185,6 +185,10 @@ services:
         max-size: "50m"
         max-file: "5"
 ```
+
+### fail2ban behind a reverse proxy
+
+With `USE_HTTP=1`, error-log entries show the *real* attacker IP (via `mod_remoteip` honoring `X-Forwarded-For`) rather than the proxy's docker IP — useful for visibility and audit.  However, fail2ban's iptables actions inside the container can only filter packets it actually receives, which always come from the proxy peer (e.g. Caddy).  In this topology the in-container bans are effectively audit-only; for real enforcement, apply rate limiting or IP banning at the reverse-proxy layer.
 
 ### Links
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -107,6 +107,8 @@ docker run -d --name bluesky \
   -v /var/docker/bluesky/bluesky.ssh:/home/bluesky/.ssh \
   -v /var/docker/bluesky/pkg:/tmp/pkg \
   --cap-add=NET_ADMIN \
+  --log-opt max-size=50m \
+  --log-opt max-file=5 \
   -p 80:80 \
   -p 443:443 \
   -p 3122:3122 \
@@ -151,6 +153,38 @@ docker exec -it bluesky bash
 ```
 
 Apache request and error logs are mirrored to the container's stdout in addition to being written to `/var/log/apache2/` inside the container, so `docker logs bluesky` is useful for live troubleshooting while the on-disk files remain available via `docker exec`.  All three log groups (`/var/log/apache2/*.log`, `/var/log/auth.log`, `/var/log/fail2ban.log`) are rotated by `logrotate` (run via cron); see `LOG_ROTATE_SIZE` and `LOG_ROTATE_KEEP` above to tune.
+
+### Docker daemon log rotation
+
+Because Apache logs are now mirrored to the container's stdout, anything written to those logs also accumulates on the **host** at `/var/lib/docker/containers/<id>/<id>-json.log`.  Docker's default `json-file` logging driver does not cap or rotate that file, so over time it can fill the host disk — at a busy BlueSky server with frequent client check-ins this can be tens of MB per day.
+
+The example `docker run` command above passes `--log-opt max-size=50m --log-opt max-file=5`, which caps the per-container log footprint on the host at roughly 250 MB and rotates older content automatically.  Adjust to taste; you likely never need more than a few hundred MB of historical `docker logs` for troubleshooting.
+
+If you prefer a host-wide default instead of per-container flags, set it once in `/etc/docker/daemon.json` and restart the Docker daemon:
+
+```json
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "50m",
+    "max-file": "5"
+  }
+}
+```
+
+For `docker-compose` users, the equivalent goes under the service definition:
+
+```yaml
+services:
+  bluesky:
+    image: ghcr.io/blueskytools/blueskyconnect
+    # ...the rest of your existing config...
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
+```
 
 ### Links
 

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -11,8 +11,21 @@ command=/usr/sbin/sshd -D -e
 autorestart=true
 redirect_stderr=true
 
+[program:apache-log-tail]
+command=/usr/bin/tail -n0 -F /var/log/apache2/access.log /var/log/apache2/error.log
+priority=10
+autorestart=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+
 [program:apache2]
 command=/bin/bash -c "source /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND"
+redirect_stderr=true
+
+[program:cron]
+command=/usr/sbin/cron -f
+autorestart=true
 redirect_stderr=true
 
 [program:fail2ban]


### PR DESCRIPTION
Includes some improvements for docker users.

- #54 Apache/auth/fail2ban log rotation:
  - Sane defaults
  - Configurable via ENV variables
  - Prevents docker container from filling up

Big fixes:
- #70 Cron installed - fixes temp purge and periodic check of clients for alerts
- #71 When behind a reverse proxy show the remote client IP