### PR TITLE
Keep DB hostName in sync with ComputerName + fix smart-quote mojibake

### DIFF
--- a/Client/bluesky.sh
+++ b/Client/bluesky.sh
@@ -140,6 +140,8 @@ function reKey {
   if [ "$wmCG" != "" ]; then
   	hostName="$wmCG - $hostName"
   fi
+  # transliterate to ASCII so smart quotes / accents don't mojibake server-side
+  hostName=`echo "$hostName" | iconv -f UTF-8 -t ASCII//TRANSLIT 2>/dev/null`
 
   # upload info to get registered
   uploadResult=`callApi "serialNum=$serialNum" "actionStep=register" "hostName=$hostName"`

--- a/Client/bluesky.sh
+++ b/Client/bluesky.sh
@@ -41,6 +41,15 @@ function callApi {
   echo "$result"
 }
 
+buildHostName() {
+  hostName=$(scutil --get ComputerName)
+  [[ -z $hostName ]] && hostName=$(hostname)
+  wmCG=$(defaults read /Library/MonitoringClient/ClientSettings ClientGroup)
+  [[ $wmCG ]] && hostName="$wmCG - $hostName"
+  # transliterate to ASCII so smart quotes / accents don't mojibake server-side
+  hostName=$(echo "$hostName" | iconv -f UTF-8 -t ASCII//TRANSLIT 2>/dev/null)
+}
+
 function getAutoPid {
   autoPid=`head -n 1 "$ourHome/autossh.pid"`
   if [ "$autoPid" != "" ]; then
@@ -131,17 +140,8 @@ function reKey {
     exit 1
   fi
 
-  # get sharing name and Watchman Monitoring client group if present
-  hostName=`scutil --get ComputerName`
-  if [ "$hostName" == "" ]; then
- 	hostName=`hostname`
-  fi
-  wmCG=`defaults read /Library/MonitoringClient/ClientSettings ClientGroup`
-  if [ "$wmCG" != "" ]; then
-  	hostName="$wmCG - $hostName"
-  fi
-  # transliterate to ASCII so smart quotes / accents don't mojibake server-side
-  hostName=`echo "$hostName" | iconv -f UTF-8 -t ASCII//TRANSLIT 2>/dev/null`
+  # build host name (sharing name + optional Watchman Monitoring client group)
+  buildHostName
 
   # upload info to get registered
   uploadResult=`callApi "serialNum=$serialNum" "actionStep=register" "hostName=$hostName"`
@@ -153,6 +153,10 @@ function reKey {
 
   /usr/libexec/PlistBuddy -c "Add :keytime integer `date +%s`" "$ourHome/settings.plist" 2> /dev/null
   /usr/libexec/PlistBuddy -c "Set :keytime `date +%s`" "$ourHome/settings.plist"
+
+  # seed hostnamecache so the next status check-in doesn't redundantly resend
+  /usr/libexec/PlistBuddy -c "Add :hostnamecache string $hostName" "$ourHome/settings.plist" 2> /dev/null
+  /usr/libexec/PlistBuddy -c "Set :hostnamecache $hostName" "$ourHome/settings.plist"
 }
 
 function restartConnection {
@@ -441,7 +445,19 @@ if [ "$defaultUser" != "" ]; then
 fi
 
 #autossh is running - check against server
-connStat=`callApi "serialNum=$serialNum" "actionStep=status"`
+# include hostName on status only when the ComputerName has actually changed
+buildHostName
+cachedName=$(/usr/libexec/PlistBuddy -c "Print :hostnamecache" "$ourHome/settings.plist" 2> /dev/null)
+if [[ $hostName != "$cachedName" ]]; then
+  connStat=$(callApi "serialNum=$serialNum" "actionStep=status" "hostName=$hostName")
+else
+  connStat=$(callApi "serialNum=$serialNum" "actionStep=status")
+fi
+# cache the value once the server has acknowledged it (any non-empty response)
+if [[ $connStat ]]; then
+  /usr/libexec/PlistBuddy -c "Add :hostnamecache string $hostName" "$ourHome/settings.plist" 2> /dev/null
+  /usr/libexec/PlistBuddy -c "Set :hostnamecache $hostName" "$ourHome/settings.plist"
+fi
 if [ "$connStat" != "OK" ]; then
   if [ "$connStat" == "selfdestruct" ]; then
     killShells

--- a/Server/processor.sh
+++ b/Server/processor.sh
@@ -83,7 +83,10 @@ else
 	  fi
   fi
   #set update
-  myQry="update computers set registered='$timeStamp', sharingname='$hostName' where id='$compRec'"
+  # refresh names like the status path does: sharingname always tracks the Mac,
+  # hostname only when it still matches the prior sharingname (i.e. unedited).
+  # hostname is assigned first so the IF() reads sharingname before it changes.
+  myQry="update computers set registered='$timeStamp', hostname=if(hostname=sharingname,'$hostName',hostname), sharingname='$hostName' where id='$compRec'"
 fi
 # above if/then should end in the appropriate query - either insert for new, or update for existing
 $myCmd "$myQry"
@@ -124,9 +127,12 @@ fi
 # hostname from being overwritten (only auto-updates hostname when it still
 # matches the prior sharingname)
 if [[ $hostName ]]; then
+  # hostname is assigned before sharingname on purpose: MySQL evaluates SET
+  # left-to-right using already-updated values, so the IF() must read the prior
+  # sharingname before we overwrite it
   myQry="update computers
-    set sharingname='$hostName',
-        hostname=if(hostname=sharingname,'$hostName',hostname)
+    set hostname=if(hostname=sharingname,'$hostName',hostname),
+        sharingname='$hostName'
     where serialnum='$serialNum'"
   $myCmd "$myQry"
 fi

--- a/Server/processor.sh
+++ b/Server/processor.sh
@@ -120,6 +120,17 @@ fi
 # attempts an ssh connection back through the tunnel
 # also sends self destruct, notify mail
 
+# refresh names if the client reported one; the IF() keeps an admin-edited
+# hostname from being overwritten (only auto-updates hostname when it still
+# matches the prior sharingname)
+if [[ $hostName ]]; then
+  myQry="update computers
+    set sharingname='$hostName',
+        hostname=if(hostname=sharingname,'$hostName',hostname)
+    where serialnum='$serialNum'"
+  $myCmd "$myQry"
+fi
+
 # self destruct
 myQry="select selfdestruct from computers where serialnum='$serialNum'"
 selfDestruct=`$myCmd "$myQry"`


### PR DESCRIPTION
## Summary

Keeps the BlueSky DB's record of a Mac's name in sync with its actual `ComputerName`, and stops smart quotes from corrupting that name on the way to the server. Addresses #55. Changes:

### 🐛 Fix smart-quote mojibake `[Client]`
Computer names with curly punctuation (e.g. `admin's iMac`) were arriving mangled as `adminâ€™s iMac` — the client sent valid UTF-8 but it got read back as cp1252. `buildHostName` now runs the name through `iconv -f UTF-8 -t ASCII//TRANSLIT`, so the value on the wire (and in the DB) is plain ASCII.

### ✨ Refresh the name on every check-in (not just re-key) `[Client]` `[Server]`
Previously the name was only POSTed during `reKey`, which on a healthy long-lived client almost never runs — so a Mac renamed in System Settings drifted in the DB indefinitely. Now:

- **Client:** the `actionStep=status` POST (every ~5 min) piggy-backs `hostName` **only when** the current `ComputerName` differs from a cached value in `settings.plist`. Steady-state check-ins are unchanged — no extra wire traffic or DB writes when nothing changed. The cache is written only after the server acknowledges, so a failed POST retries next cycle.
- **Server:** `processor.sh` does one conditional UPDATE wherever a `hostName` is supplied (both the `status` case and the `register` re-enroll path):
  - `sharingname` (auto-populated, detail-view only) always tracks the latest name.
  - `hostname` (the admin-curated "Name" column) is refreshed **only if it still equals the prior `sharingname`** — i.e. an admin hasn't manually relabeled the Mac. Manual relabels are preserved, via `IF(hostname=sharingname, …)`.

### 🐛 Two follow-up fixes to the sync logic `[Server]`
- **Query ordering.** MySQL evaluates `SET` assignments left-to-right using already-updated values, so the original `set sharingname=…, hostname=IF(hostname=sharingname,…)` compared `hostname` against the *new* `sharingname` and never updated the Name column — not even on a plain in-sync rename. `hostname` is now assigned **before** `sharingname` so the `IF()` reads the prior value. (Verified against MySQL 5.7.)
- **Re-enroll path.** A wiped/redeployed Mac that re-enrolls with an existing serial took `register`'s UPDATE branch, which refreshed `sharingname` only and left the Name column on the pre-wipe value. It now applies the same guarded update, so a redeploy heals the Name when unedited and preserves a genuine admin label.

After these, the only writer that diverges `hostname` from `sharingname` is an admin editing Name in the web UI.

## Compatibility
Safe in both rolling-upgrade directions:
- **Old client + new server:** clients only send `hostName` on `reKey` as before; the new UPDATE no-ops on an empty value.
- **New client + old server:** `collector.php` already forwards `hostName` as `$3`; an old `processor.sh` simply ignores it in the `status` case.

## Upgrading

### Optional: reconcile existing device names
The fixes above only keep names in sync **going forward**. Devices whose `hostname`/`sharingname` already drifted under the old behavior won't self-heal (the guard correctly leaves a diverged Name alone). To force existing rows back into sync, an operator can run a one-time SQL reconcile.

> ⚠️ This **overwrites the "Name" column** with the device's current sharing name, including any names an admin typed by hand. Preview first, and use the targeted variant below if you have custom labels to keep.

**Preview what would change** (Docker — drop `docker exec bluesky` for non-Docker):
```bash
docker exec bluesky /usr/bin/mysql --defaults-file=/var/local/my.cnf --default-character-set=utf8 BlueSky -t \
  -e "SELECT serialnum, hostname AS current_name, sharingname AS will_become
      FROM computers
      WHERE sharingname IS NOT NULL AND sharingname <> '' AND hostname <> sharingname;"
```

**Force-resync all diverged names:**
```bash
docker exec bluesky /usr/bin/mysql --defaults-file=/var/local/my.cnf --default-character-set=utf8 BlueSky \
  -e "UPDATE computers SET hostname = sharingname
      WHERE sharingname IS NOT NULL AND sharingname <> '' AND hostname <> sharingname;"
```

**Targeted variant** — only reset Names that still match the auto/enrollment value (those embedding the serial number), preserving hand-typed labels:
```bash
docker exec bluesky /usr/bin/mysql --defaults-file=/var/local/my.cnf --default-character-set=utf8 BlueSky \
  -e "UPDATE computers SET hostname = sharingname
      WHERE sharingname IS NOT NULL AND sharingname <> '' AND hostname <> sharingname
        AND hostname LIKE CONCAT('%', serialnum, '%');"
```

Non-Docker hosts run the same `mysql --defaults-file=/var/local/my.cnf … ` invocation directly on the server (omit the `docker exec bluesky` prefix).

## Conventions
New/changed shell follows `CONTRIBUTING.md` / `.editorconfig` — `funcName() {}`, `[[ ]]`, `$( )`, `space_redirects`, 2-space indent. New hunks are `shellcheck`-clean (pre-existing legacy backtick findings untouched).

## Testing
Verified end-to-end on a live server (Docker) + the new client: in-sync rename heals both columns, admin-labeled rows are preserved, and the same holds across a simulated re-enroll. Query-ordering and re-enroll behavior also confirmed directly against MySQL 5.7.
