### PR TITLE
Add LEGACY_CLIENT flag to omit curl/openssl from client pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV IN_DOCKER=1 \
     EMAILALERT=root@localhost \
     LOG_ROTATE_SIZE=100M \
     LOG_ROTATE_KEEP=7 \
+    LEGACY_CLIENT=0 \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     DEBIAN_FRONTEND=noninteractive \

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,6 +33,7 @@ LOG_ROTATE_SIZE | 100M | Size threshold for log rotation (applies to Apache, aut
 LOG_ROTATE_KEEP | 7 | Number of rotated copies to retain (older are deleted)
 DEFAULT_USER | | Default username bluesky uses when connecting to a client
 INSECURE_CIPHERS | | Set to any value to allow the use of chacha20-poly1305 ssh cipher (bluesky <= 2.3.2)
+LEGACY_CLIENT | 0 | Set to 1 to bundle the curl/openssl binaries needed by macOS < 10.14 clients (LetsEncrypt CA workaround). Omitted by default so the client pkg ships no unmaintained binaries
 
 ### Signing & notarization (optional)
 

--- a/docker/build_pkg.sh
+++ b/docker/build_pkg.sh
@@ -16,6 +16,12 @@ stagePayload() {
   rm -rf /tmp/pkg-payload/.* 2> /dev/null
   cp -RL /usr/local/bin/BlueSkyConnect/Client/* /tmp/pkg-payload/
   cp -R /usr/local/bin/BlueSkyConnect/Client/.ssh /tmp/pkg-payload/
+  # The bundled curl/openssl are only used on macOS < 10.14 (LetsEncrypt CA
+  # workaround). Omit them by default so the pkg carries no unmaintained
+  # binaries; LEGACY_CLIENT=1 ships them for fleets with pre-Mojave Macs.
+  if [[ "$LEGACY_CLIENT" != "1" ]]; then
+    rm -rf /tmp/pkg-payload/curl /tmp/pkg-payload/openssl
+  fi
 }
 
 mkdir -p /tmp/pkg

--- a/docker/sign-helpers.sh
+++ b/docker/sign-helpers.sh
@@ -211,6 +211,7 @@ computeBuildFingerprint() {
       /usr/local/bin/notarize-pkgs.sh \
       /usr/local/bin/rcodesign 2> /dev/null
     if [[ "$pkgname" == "BlueSky" ]]; then
+      echo "LEGACY_CLIENT=${LEGACY_CLIENT:-0}"
       sha256sum /usr/local/bin/build_pkg.sh 2> /dev/null
       ( cd "$sourceRoot/Client" && find . -type f -print0 | sort -z | xargs -0 sha256sum )
     elif [[ "$pkgname" == "BlueSkyAdmin" ]]; then


### PR DESCRIPTION
## Summary

The bundled `curl`/`openssl` binaries in the client only serve macOS < 10.14 (the LetsEncrypt CA-chain workaround). They shipped to every client regardless, where the unmaintained binaries can trip security scanners and carry unpatched CVEs.

This defaults the client pkg to **macOS 10.14+** by stripping `curl/` and `openssl/` from the payload, with an opt-in env var to restore the legacy bundle.

Closes #66.

## Changes

- **`docker/build_pkg.sh`** — `stagePayload()` drops `curl/` + `openssl/` from the payload unless `LEGACY_CLIENT=1` (stripped in `stagePayload` so the sign-fallback restage stays consistent).
- **`Dockerfile`** — adds `LEGACY_CLIENT=0` to the ENV defaults.
- **`docker/sign-helpers.sh`** — folds `LEGACY_CLIENT` into the BlueSky build fingerprint so toggling the flag busts the pkg cache.
- **`docker/README.md`** — documents the variable.

## Notes

- `cacert.pem` is **retained** — it's a separate axis (< 10.15) and is used by system `curl` too; it's not an executable.
- No runtime client change needed: `bluesky.sh`'s `-f .../curl/bin/curl` guard already falls back to system `curl` when the binary is absent.
- ⚠️ **Behavior change**: the default flips for fleets still supporting pre-Mojave Macs — they must set `-e LEGACY_CLIENT=1`. Worth a breaking-change callout in the release notes.
