### PR TITLE
Use bootstrap/bootout for launchd on macOS 11+

### DIFF
--- a/Client/helper.sh
+++ b/Client/helper.sh
@@ -36,11 +36,39 @@ function logMe {
   fi
 }
 
+# load/unload system LaunchDaemons; macOS 11+ uses bootstrap/bootout, 10.x uses load/unload.
+# Accepts one or more plist paths (globs are fine); each is handled on its own so an
+# already-loaded (or already-unloaded) daemon won't abort the rest.
+function loadDaemon {
+  if [ ${osVersionMajor:-10} -ge 11 ]; then
+    for plistPath in "$@"; do
+      launchctl bootstrap system "$plistPath" 2> /dev/null
+    done
+  else
+    launchctl load -w "$@"
+  fi
+}
+
+function unloadDaemon {
+  if [ ${osVersionMajor:-10} -ge 11 ]; then
+    for plistPath in "$@"; do
+      launchctl bootout system "$plistPath" 2> /dev/null
+    done
+  else
+    launchctl unload "$@"
+  fi
+}
+
 #if server.plist is not present, error and exit
 if [ ! -e "$ourHome/server.plist" ]; then
   echo "server.plist is not installed. Please double-check your setup."
   exit 2
 fi
+
+# get the version of the OS so we can ensure compatiblity (needed before any loadDaemon call)
+osRaw=$(sw_vers -productVersion)
+osVersionMajor=$(echo "$osRaw" | awk -F . '{ print $1 }')
+osVersionMinor=$(echo "$osRaw" | awk -F . '{ print $2 }')
 
 #if BlueSky 1.5 is present, get rid of it
 if [[ -e /Library/Mac-MSP/BlueSky/helper.sh || ! -z $(pkgutil --pkgs | grep com.mac-msp.bluesky) ]]; then
@@ -68,14 +96,10 @@ if [ "$helpWithWhat" == "selfdestruct" ]; then
     rm -rf "$ourHome"
     dscl . -delete /Users/bluesky
     pkgutil --forget com.solarwindsmsp.bluesky.pkg
-    launchctl unload /Library/LaunchDaemons/com.solarwindsmsp.bluesky* && rm -f /Library/LaunchDaemons/com.solarwindsmsp.bluesky*
+    unloadDaemon /Library/LaunchDaemons/com.solarwindsmsp.bluesky*
+    rm -f /Library/LaunchDaemons/com.solarwindsmsp.bluesky*
     exit 0
 fi
-
-# get the version of the OS so we can ensure compatiblity
-osRaw=`sw_vers -productVersion`
-osVersionMajor=`echo "$osRaw" | awk -F . '{ print $1 }'`
-osVersionMinor=`echo "$osRaw" | awk -F . '{ print $2 }'`
 
 #check if user exists and create if necessary
 userCheck=`dscl . -read /Users/bluesky RealName`
@@ -116,19 +140,16 @@ chown -R bluesky "$ourHome"
 #help me help you.  help me... help you.
 dseditgroup -o edit -a bluesky -t user com.apple.access_ssh 2> /dev/null
 systemsetup -setremotelogin on &> /dev/null
-if [ ${osVersionMajor:-10} -eq 10 ] && [ ${osVersionMinor} -lt 15 ]; then
+if [ ${osVersionMajor:-10} -ge 11 ]; then
+  # systemsetup -setremotelogin needs Full Disk Access on modern macOS (issue #54);
+  # enable and start Apple's sshd through launchd instead, which doesn't go through TCC
+  launchctl enable system/com.openssh.sshd
+  launchctl bootstrap system /System/Library/LaunchDaemons/ssh.plist 2> /dev/null
+elif [ ${osVersionMajor:-10} -eq 10 ] && [ ${osVersionMinor} -lt 15 ]; then
   systemsetup -setremotelogin on &> /dev/null
 else
   launchctl load -w /System/Library/LaunchDaemons/ssh.plist
 fi
-
-# commenting out on 1.12
-# re-intro when we can test a more reliable method of determining a VNC server
-# vncOn=`ps -ax | grep ARDAgent | grep -v grep`
-# if [ "$vncOn" == "" ]; then
-#   logMe "Starting ARD agent"
-#   /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -configure -activate -access -on -privs -ControlObserve -allowAccessFor -allUsers -quiet
-# fi
 
 #if permissions are wrong on the home folder, this will fix
 if [ "$helpWithWhat" == "fixPerms" ]; then
@@ -154,9 +175,6 @@ if [ "$setCheck" == "" ]; then
   logMe "Helper is resetting the settings plist"
   rm -f "$ourHome/settings.plist"
   /usr/libexec/PlistBuddy -c "Add :keytime integer 0" "$ourHome/settings.plist"
-  # commenting these out for 1.5, creation of variables should be more robust now
-#  /usr/libexec/PlistBuddy -c "Add :portcache integer -1" "$ourHome/settings.plist"
-#  /usr/libexec/PlistBuddy -c "Add :serial string 0" "$ourHome/settings.plist"
   chown bluesky "$ourHome/settings.plist"
 fi
 
@@ -217,7 +235,7 @@ if [ ${weLaunched:-0} -lt 4 ]; then
   fi
   chmod 644 /Library/LaunchDaemons/com.solarwindsmsp.bluesky.*
   chown root:wheel /Library/LaunchDaemons/com.solarwindsmsp.bluesky.*
-  launchctl load -w /Library/LaunchDaemons/com.solarwindsmsp.bluesky.*
+  loadDaemon /Library/LaunchDaemons/com.solarwindsmsp.bluesky.*
 fi
 
 exit 0

--- a/Client/reconnect.sh
+++ b/Client/reconnect.sh
@@ -31,8 +31,17 @@ if [ "$1" == "wake" ]; then
 else
   logMe "Network state change detected, Reloading bluesky service..."
 fi
+
+# macOS 11+ uses bootout/bootstrap; 10.x uses the legacy unload/load
+osVersionMajor=$(sw_vers -productVersion | awk -F . '{ print $1 }')
+
 sleep 3
-launchctl unload /Library/LaunchDaemons/com.solarwindsmsp.bluesky.plist
-launchctl load -w /Library/LaunchDaemons/com.solarwindsmsp.bluesky.plist
+if [ ${osVersionMajor:-10} -ge 11 ]; then
+  launchctl bootout system /Library/LaunchDaemons/com.solarwindsmsp.bluesky.plist 2> /dev/null
+  launchctl bootstrap system /Library/LaunchDaemons/com.solarwindsmsp.bluesky.plist
+else
+  launchctl unload /Library/LaunchDaemons/com.solarwindsmsp.bluesky.plist
+  launchctl load -w /Library/LaunchDaemons/com.solarwindsmsp.bluesky.plist
+fi
 
 exit 0


### PR DESCRIPTION
## Summary

Modernizes how the macOS client loads and unloads its LaunchDaemons. `launchctl load`/`unload` is the legacy API; macOS 11+ should use the domain-target form (`bootstrap`/`bootout`). This gates the new API on `osVersionMajor >= 11` and keeps the legacy calls on 10.x.

## Changes

**`Client/helper.sh`**
- New `loadDaemon` / `unloadDaemon` helpers: `bootstrap`/`bootout system` on macOS 11+, `load -w`/`unload` on 10.x. Each plist in a glob is handled individually (stderr suppressed) so an already-(un)loaded daemon can't abort the rest — preserving the forgiving behavior of legacy `load -w`/`unload`.
- OS-version detection moved above the cleanup/selfdestruct blocks so it's available before the first `loadDaemon`/`unloadDaemon` call.
- Selfdestruct now calls `unloadDaemon` then `rm -f` on its own line (was `unload && rm`) — `bootout` can return non-zero when a daemon wasn't loaded, and we never want that to leave plists behind during a self-destruct.
- Babysit reload routed through `loadDaemon`.

**`Client/reconnect.sh`**
- Reload on network/wake events uses `bootout` + `bootstrap` on 11+, legacy `unload`/`load -w` below.

## Remote Login (ssh) enablement

`helper.sh` enabled Remote Login on 10.15+ via `launchctl load -w /System/Library/LaunchDaemons/ssh.plist` specifically because `systemsetup -setremotelogin on` requires Full Disk Access on 10.15+ (see logicnow/BlueSky#54) — and the launchctl path doesn't go through TCC. The modern equivalent preserves that FDA-free property:

```bash
launchctl enable system/com.openssh.sshd
launchctl bootstrap system /System/Library/LaunchDaemons/ssh.plist
```

`enable` covers the persistent-enable that `load -w`'s `-w` did. 10.15.x keeps `load -w`; pre-10.15 keeps `systemsetup`.

## Notes

- The old BlueSky 1.5 cleanup (`com.mac-msp.bluesky*`) intentionally stays on legacy `launchctl unload` — it only runs on machines old enough to still have 1.5.
- Lint: these files predate shellcheck/shfmt cleanliness (pervasive backticks, unquoted vars). New code matches the surrounding style; only authored/moved lines were modernized to `$(...)`. `shfmt -w` was deliberately not run, as it would reformat the whole file (mixed indentation) into unrelated churn.

## Testing

- `bash -n` passes on both scripts.
- Not yet exercised end-to-end on a real 11+ client — the practical loop is install the client pkg and confirm the daemons load and Remote Login comes up.
